### PR TITLE
Add `input.txt` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ dist
 .pnp.\*
 
 .idea
+
+**/*/input.txt


### PR DESCRIPTION
AoC puzzle inputs are under copyright (as referenced here https://www.reddit.com/r/adventofcode/wiki/faqs/copyright/puzzle_texts/). The repo would add the inputs to Git by default, potentially exposing them publicly. This PR adds the `input.txt` files to gitignore to avoid this.